### PR TITLE
Add conformsTo to identify profile conformance

### DIFF
--- a/docs/profiles/0.1-DRAFT/process_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/process_run_crate.md
@@ -21,19 +21,32 @@ By "implicit workflow" we mean that the composition of these tools may have been
 This profile requires the indication of [Software used to create files](https://www.researchobject.org/ro-crate/1.1/provenance.html#software-used-to-create-files), namely a [SoftwareApplication](http://schema.org/SoftwareApplication) (the tool) and a [CreateAction](http://schema.org/CreateAction) (the execution of said tool).
 
 
-## Example
+## Example Metadata File (`ro-crate-metadata.json`)
 
 ```json
-[
+{ "@context": "https://w3id.org/ro/crate/1.1/context", 
+  "@graph": [
+    {
+        "@id": "ro-crate-metadata.json",
+        "@type": "CreativeWork",
+        "conformsTo": {"@id": "https://w3id.org/ro/crate/1.1"},
+        "about": {"@id": "./"}
+    },
     {
         "@id": "./",
         "@type": "Dataset",
+        "conformsTo": { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
         "hasPart": [
             {"@id": "pics/2017-06-11%2012.56.14.jpg"},
             {"@id": "pics/sepia_fence.jpg"}
         ],
         "mentions": {"@id": "#SepiaConversion_1"},
         "name": "My Pictures"
+    },
+    {   "@id": "https://w3id.org/ro/wfrun/process/0.1",
+        "@type": "CreativeWork",
+        "name": "Process Run Crate",
+        "version": "0.1"
     },
     {
         "@id": "https://www.imagemagick.org/",
@@ -73,9 +86,12 @@ This profile requires the indication of [Software used to create files](https://
         "name": "Stian Soiland-Reyes"
     }
 ]
+}
 ```
 
 Note that the command line shown in the action's `description` is not directly re-executable, as file paths are not required to match the RO-Crate locations. For a more structural and reproducible description of tool executions, see [Workflow Run Crate](workflow_run_crate).
+
+
 
 
 ## Requirements
@@ -86,6 +102,15 @@ Note that the command line shown in the action's `description` is not directly r
    <td><strong>Property</strong></td>
    <td><strong>Required?</strong></td>
    <td><strong>Description</strong></td>
+  </tr>
+
+  <tr>
+   <th colspan="3"><strong>Dataset</strong> (the <a href="https://www.researchobject.org/ro-crate/1.1/root-data-entity.html">root data entity</a>, e.g. <code>"@id": "./"</code>)</th>
+  </tr>
+  <tr>
+   <td>conformsTo</td>
+   <td>MUST</td>
+   <td>MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, e.g. <code>{"@id": "https://w3id.org/ro/wfrun/process/0.1"}</code>
   </tr>
 
   <tr>

--- a/docs/profiles/0.1-DRAFT/process_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/process_run_crate.md
@@ -35,7 +35,7 @@ This profile requires the indication of [Software used to create files](https://
     {
         "@id": "./",
         "@type": "Dataset",
-        "conformsTo": { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
+        "conformsTo": {"@id": "https://w3id.org/ro/wfrun/process/0.1"},
         "hasPart": [
             {"@id": "pics/2017-06-11%2012.56.14.jpg"},
             {"@id": "pics/sepia_fence.jpg"}
@@ -92,8 +92,6 @@ This profile requires the indication of [Software used to create files](https://
 Note that the command line shown in the action's `description` is not directly re-executable, as file paths are not required to match the RO-Crate locations. For a more structural and reproducible description of tool executions, see [Workflow Run Crate](workflow_run_crate).
 
 
-
-
 ## Requirements
 
 <table>
@@ -110,7 +108,7 @@ Note that the command line shown in the action's `description` is not directly r
   <tr>
    <td>conformsTo</td>
    <td>MUST</td>
-   <td>MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, e.g. <code>{"@id": "https://w3id.org/ro/wfrun/process/0.1"}</code>
+   <td>MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, e.g. <code>{"@id": "https://w3id.org/ro/wfrun/process/0.1"}</code></td>
   </tr>
 
   <tr>
@@ -160,7 +158,7 @@ Note that the command line shown in the action's `description` is not directly r
   <tr>
    <td>@id</td>
    <td>MUST</td>
-   <td>A unique identifier for the execution, e.g. <code>"urn:uuid:50ec5c76-1f7a-4130-8ef6-846756b228c1"</code>, <code>"#f99a8e6c"</code>. MAY be an absolute URI, e.g. <a href="http://example.com/runs/846756b228c1">http://example.com/runs/846756b228c1</a>. The use of randomly generated <a href="https://datatracker.ietf.org/doc/html/rfc4122">UUIDs</a> (type 4) is RECOMMENDED. SHOULD be listed under <a href="http://schema.org/mentions">mentions</a> of the [root data entity](https://www.researchobject.org/ro-crate/1.1/root-data-entity.html).</td>
+   <td>A unique identifier for the execution, e.g. <code>"urn:uuid:50ec5c76-1f7a-4130-8ef6-846756b228c1"</code>, <code>"#f99a8e6c"</code>. MAY be an absolute URI, e.g. <a href="http://example.com/runs/846756b228c1">http://example.com/runs/846756b228c1</a>. The use of randomly generated <a href="https://datatracker.ietf.org/doc/html/rfc4122">UUIDs</a> (type 4) is RECOMMENDED. SHOULD be listed under <a href="http://schema.org/mentions">mentions</a> of the <a href="https://www.researchobject.org/ro-crate/1.1/root-data-entity.html">root data entity</a>.</td>
   </tr>
 
   <tr>

--- a/docs/profiles/0.1-DRAFT/provenance_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/provenance_run_crate.md
@@ -32,7 +32,7 @@ The following diagram shows the relationships between all provenance-related ent
 ## Example Metadata File (`ro-crate-metadata.json`)
 
 ```json
-{ "@context": "https://w3id.org/ro/crate/1.1/context", 
+{ "@context": "https://w3id.org/ro/crate/1.1/context",
   "@graph": [
     {
         "@id": "ro-crate-metadata.json",
@@ -47,10 +47,10 @@ The following diagram shows the relationships between all provenance-related ent
         "@id": "./",
         "@type": "Dataset",
         "conformsTo": [
-            { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
-            { "@id": "https://w3id.org/ro/wfrun/workflow/0.1" },
-            { "@id": "https://w3id.org/ro/wfrun/provenance/0.1" },
-            { "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}            
+            {"@id": "https://w3id.org/ro/wfrun/process/0.1"},
+            {"@id": "https://w3id.org/ro/wfrun/workflow/0.1"},
+            {"@id": "https://w3id.org/ro/wfrun/provenance/0.1"},
+            {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
         ],
         "hasPart": [
             {"@id": "packed.cwl"},
@@ -72,7 +72,7 @@ The following diagram shows the relationships between all provenance-related ent
         "@type": "CreativeWork",
         "name": "Workflow Run Crate",
         "version": "0.1"
-    },    
+    },
     {   "@id": "https://w3id.org/ro/wfrun/provenance/0.1",
         "@type": "CreativeWork",
         "name": "Provenance Run Crate",
@@ -321,6 +321,7 @@ The following diagram shows the relationships between all provenance-related ent
         "value": "True"
     }
 ]
+}
 ```
 
 
@@ -448,7 +449,7 @@ The requirements of this profile are those of [Workflow Run Crate](workflow_run_
   <tr>
    <td>conformsTo</td>
    <td>MUST</td>
-   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a>, <a href="https://w3id.org/ro/wfrun/workflow/0.1">Workflow Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.
+   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a>, <a href="https://w3id.org/ro/wfrun/workflow/0.1">Workflow Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.</td>
   </tr>
 
   <tr>

--- a/docs/profiles/0.1-DRAFT/provenance_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/provenance_run_crate.md
@@ -29,13 +29,29 @@ The following diagram shows the relationships between all provenance-related ent
 <img alt="Entity-relationship diagram" src="img/er_diagram.svg" width="920" />
 
 
-## Example
+## Example Metadata File (`ro-crate-metadata.json`)
 
 ```json
-[
+{ "@context": "https://w3id.org/ro/crate/1.1/context", 
+  "@graph": [
+    {
+        "@id": "ro-crate-metadata.json",
+        "@type": "CreativeWork",
+        "about": {"@id": "./"},
+        "conformsTo": [
+            {"@id": "https://w3id.org/ro/crate/1.1"},
+            {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
+        ]
+    },
     {
         "@id": "./",
         "@type": "Dataset",
+        "conformsTo": [
+            { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
+            { "@id": "https://w3id.org/ro/wfrun/workflow/0.1" },
+            { "@id": "https://w3id.org/ro/wfrun/provenance/0.1" },
+            { "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}            
+        ],
         "hasPart": [
             {"@id": "packed.cwl"},
             {"@id": "327fc7aedf4f6b69a42a7c8b808dc5a7aff61376"},
@@ -47,14 +63,25 @@ The following diagram shows the relationships between all provenance-related ent
             {"@id": "#4154dad3-00cc-4e35-bb8f-a2de5cd7dc49"}
         ]
     },
-    {
-        "@id": "ro-crate-metadata.json",
+    {   "@id": "https://w3id.org/ro/wfrun/process/0.1",
         "@type": "CreativeWork",
-        "about": {"@id": "./"},
-        "conformsTo": [
-            {"@id": "https://w3id.org/ro/crate/1.1"},
-            {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
-        ]
+        "name": "Process Run Crate",
+        "version": "0.1"
+    },
+    {   "@id": "https://w3id.org/ro/wfrun/workflow/0.1",
+        "@type": "CreativeWork",
+        "name": "Workflow Run Crate",
+        "version": "0.1"
+    },    
+    {   "@id": "https://w3id.org/ro/wfrun/provenance/0.1",
+        "@type": "CreativeWork",
+        "name": "Provenance Run Crate",
+        "version": "0.1"
+    },
+    {   "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+        "@type": "CreativeWork",
+        "name": "Workflow RO-Crate",
+        "version": "1.0"
     },
     {
         "@id": "packed.cwl",
@@ -413,6 +440,15 @@ The requirements of this profile are those of [Workflow Run Crate](workflow_run_
    <td><strong>Property</strong></td>
    <td><strong>Required?</strong></td>
    <td><strong>Description</strong></td>
+  </tr>
+
+  <tr>
+   <th colspan="3"><strong>Dataset</strong> (the <a href="https://www.researchobject.org/ro-crate/1.1/root-data-entity.html">root data entity</a>, e.g. <code>"@id": "./"</code>)</th>
+  </tr>
+  <tr>
+   <td>conformsTo</td>
+   <td>MUST</td>
+   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a>, <a href="https://w3id.org/ro/wfrun/workflow/0.1">Workflow Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.
   </tr>
 
   <tr>

--- a/docs/profiles/0.1-DRAFT/workflow_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/workflow_run_crate.md
@@ -24,10 +24,25 @@ Some workflows have multiple inputs/outputs that, in conformance with the [Biosc
 ## Example
 
 ```json
-[
+{ "@context": "https://w3id.org/ro/crate/1.1/context", 
+  "@graph": [
+    {
+        "@id": "ro-crate-metadata.json",
+        "@type": "CreativeWork",
+        "about": {"@id": "./"},
+        "conformsTo": [
+            {"@id": "https://w3id.org/ro/crate/1.1"},
+            {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
+        ]
+    },
     {
         "@id": "./",
         "@type": "Dataset",
+        "conformsTo": [
+            { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
+            { "@id": "https://w3id.org/ro/wfrun/workflow/0.1" },
+            { "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}            
+        ],
         "hasPart": [
             {"@id": "Galaxy-Workflow-Hello_World.ga"},
             {"@id": "inputs/abcdef.txt"},
@@ -37,6 +52,21 @@ Some workflows have multiple inputs/outputs that, in conformance with the [Biosc
         "license": {"@id": "http://spdx.org/licenses/CC0-1.0"},
         "mainEntity": {"@id": "Galaxy-Workflow-Hello_World.ga"},
         "mentions": {"@id": "#wfrun-5a5970ab-4375-444d-9a87-a764a66e3a47"}
+    },
+    {   "@id": "https://w3id.org/ro/wfrun/process/0.1",
+        "@type": "CreativeWork",
+        "name": "Process Run Crate",
+        "version": "0.1"
+    },
+    {   "@id": "https://w3id.org/ro/wfrun/workflow/0.1",
+        "@type": "CreativeWork",
+        "name": "Workflow Run Crate",
+        "version": "0.1"
+    },
+    {   "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+        "@type": "CreativeWork",
+        "name": "Workflow RO-Crate",
+        "version": "1.0"
     },
     {
         "@id": "Galaxy-Workflow-Hello_World.ga",
@@ -184,6 +214,15 @@ This profile inherits the requirements of [Process Run Crate](process_run_crate)
    <td><strong>Property</strong></td>
    <td><strong>Required?</strong></td>
    <td><strong>Description</strong></td>
+  </tr>
+
+  <tr>
+   <th colspan="3"><strong>Dataset</strong> (the <a href="https://www.researchobject.org/ro-crate/1.1/root-data-entity.html">root data entity</a>, e.g. <code>"@id": "./"</code>)</th>
+  </tr>
+  <tr>
+   <td>conformsTo</td>
+   <td>MUST</td>
+   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.
   </tr>
 
   <tr>

--- a/docs/profiles/0.1-DRAFT/workflow_run_crate.md
+++ b/docs/profiles/0.1-DRAFT/workflow_run_crate.md
@@ -21,10 +21,10 @@ This profile is a combination of [Process Run Crate](process_run_crate) and [Wor
 Some workflows have multiple inputs/outputs that, in conformance with the [Bioschemas ComputationalWorkflow profile](https://bioschemas.org/profiles/ComputationalWorkflow/1.0-RELEASE) are defined as [FormalParameter](https://bioschemas.org/types/FormalParameter/1.0-RELEASE) entities. It is OPTIONAL to include these definitions on a `ComputationalWorkflow`. A data entity or `PropertyValue` that realizes a `FormalParameter` definition SHOULD refer to it via [exampleOfWork](https://schema.org/exampleOfWork); additionally, if the data entity or `PropertyValue` is an illustrative example of the parameter, the latter MAY refer back to the former using the reverse property [workExample](https://schema.org/workExample). This links the `input` of a `ComputationalWorkflow` to the `object` of a `CreateAction`, and the `output` of a `ComputationalWorkflow` to the `result` of a `CreateAction`. An `object` item that does not match a slot in the workflow's input interface (e.g., a [configuration file](process_run_crate#referencing-configuration-files) read from a predefined path) MUST NOT refer to a `FormalParameter` of the `ComputationalWorkflow` via `exampleOfWork`. A `FormalParameter` that maps to a `PropertyValue` SHOULD have a subclass of [DataType](https://schema.org/DataType) (e.g., [Integer](https://schema.org/Integer)) &mdash; or [PropertyValue](https://schema.org/PropertyValue), in the case of dictionary-like structured types &mdash; as its `additionalType`. See [CWL parameter mapping](/workflow-run-crate/cwl_param_mapping) for an example.
 
 
-## Example
+## Example Metadata File (`ro-crate-metadata.json`)
 
 ```json
-{ "@context": "https://w3id.org/ro/crate/1.1/context", 
+{ "@context": "https://w3id.org/ro/crate/1.1/context",
   "@graph": [
     {
         "@id": "ro-crate-metadata.json",
@@ -39,9 +39,9 @@ Some workflows have multiple inputs/outputs that, in conformance with the [Biosc
         "@id": "./",
         "@type": "Dataset",
         "conformsTo": [
-            { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
-            { "@id": "https://w3id.org/ro/wfrun/workflow/0.1" },
-            { "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}            
+            {"@id": "https://w3id.org/ro/wfrun/process/0.1"},
+            {"@id": "https://w3id.org/ro/wfrun/workflow/0.1"},
+            {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
         ],
         "hasPart": [
             {"@id": "Galaxy-Workflow-Hello_World.ga"},
@@ -201,6 +201,7 @@ Some workflows have multiple inputs/outputs that, in conformance with the [Biosc
         "name": "Workflow Execution Summary of Hello World"
     }
 ]
+}
 ```
 
 
@@ -222,7 +223,7 @@ This profile inherits the requirements of [Process Run Crate](process_run_crate)
   <tr>
    <td>conformsTo</td>
    <td>MUST</td>
-   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.
+   <td>Array MUST reference a <code>CreativeWork</code> entity with an <code>@id</code> URI that is consistent with the versioned <em>Permalink</em> of this document, and SHOULD also reference versioned permalinks for <a href="https://w3id.org/ro/wfrun/process/0.1">Process Run Crate</a> and <a href="https://w3id.org/workflowhub/workflow-ro-crate/1.0">Workflow RO-Crate</a>.</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
Following https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles but with "conformsTo" applied to "./" as suggested in https://github.com/ResearchObject/ro-crate/issues/153#issuecomment-1240446098 rather than `conformsTo`

Example for provenance crate.

```json
     {
       "@id": "ro-crate-metadata.json",
       "@type": "CreativeWork",
       "about": {"@id": "./"},
       "conformsTo": [
           {"@id": "https://w3id.org/ro/crate/1.1"},
           {"@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
       ]
     },
     {
       "@id": "./",
       "@type": "Dataset",
       "conformsTo": [
           { "@id": "https://w3id.org/ro/wfrun/process/0.1" },
           { "@id": "https://w3id.org/ro/wfrun/workflow/0.1" },
           { "@id": "https://w3id.org/ro/wfrun/provenance/0.1" },
           { "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"}
       ],
    {   "@id": "https://w3id.org/ro/wfrun/process/0.1",
        "@type": "CreativeWork",
        "name": "ProcessRun Crate",
        "version": "0.1"
    },
    {   "@id": "https://w3id.org/ro/wfrun/workflow/0.1",
        "@type": "CreativeWork",
        "name": "Workflow Run Crate",
        "version": "0.1"
    },
    {   "@id": "https://w3id.org/ro/wfrun/provenance/0.1",
        "@type": "CreativeWork",
        "name": "Provenance Run Crate",
        "version": "0.1"
    },
    {   "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
        "@type": "CreativeWork",
        "name": "Workflow RO-Crate",
        "version": "1.0"
    },
```

Process Crate:
 - `https://w3id.org/ro/wfrun/process/0.1`

Workflow Crate:
- `https://w3id.org/ro/wfrun/process/0.1`
- `https://w3id.org/ro/wfrun/workflow/0.1`
- `https://w3id.org/workflowhub/workflow-ro-crate/1.0`

Provenance Crate: 
- `https://w3id.org/ro/wfrun/process/0.1`
- `https://w3id.org/ro/wfrun/workflow/0.1`
- `https://w3id.org/ro/wfrun/provenance/0.1`
- `https://w3id.org/workflowhub/workflow-ro-crate/1.0`


Notes:
* These PIDs won't work before 0.1 versions of the profiles are released, e.g. https://w3id.org/ro/wfrun/process/0.1 redirects to https://www.researchobject.org/workflow-run-crate/profiles/0.1/process_run_crate which is currently at https://www.researchobject.org/workflow-run-crate/profiles/0.1-DRAFT/process_run_crate etc.
* https://www.researchobject.org/ro-crate/1.2-DRAFT/profiles does not have the concept of inheritence, perhaps deliberately so that clients can assume profile conformance of the bases even if it has no knowledge of the other profiles (inheritence would also require retrieval of machine-readable Crate profiles)
* `conformsTo` always goes to a profile PID with `major.minor` version
* https://about.workflowhub.eu/Workflow-RO-Crate/#metadata-file-descriptor assumes RO-Crate 1.1 (which said nothing about profiles), and applies `conformsTo` to `ro-crate-metadata.json`. To keep conformance with that one (before it can be updated to 1.2 once that is released) I have kept that in the examples here, but also added the Workflow RO-Crate PID to make it consistent with 1.2
* It is not sufficient with just `wfrun/process` and  `workflowhub/workflow-ro-crate` as `wfrun/workflow` adds a requirement for the `CreateAction` to be connected to the `mainEntity` workflow
* `wfrun/provenance` is again different from ` wfrun/workflow`, e.g. it adds `OrganizeAction` and `ControlAction`