### PR TITLE
Add resourceUsage to the profile crate

### DIFF
--- a/docs/profiles/0.5-DRAFT/process_run_crate/ro-crate-metadata.json
+++ b/docs/profiles/0.5-DRAFT/process_run_crate/ro-crate-metadata.json
@@ -336,6 +336,7 @@
       { "@id": "https://w3id.org/ro/terms/workflow-run#registry" },
       { "@id": "https://w3id.org/ro/terms/workflow-run#tag" },
       { "@id": "https://w3id.org/ro/terms/workflow-run#containerImage" },
+      { "@id": "https://w3id.org/ro/terms/workflow-run#resourceUsage" },
       { "@id": "https://w3id.org/ro/terms/workflow-run#md5" },
       { "@id": "https://w3id.org/ro/terms/workflow-run#sha1" },
       { "@id": "https://w3id.org/ro/terms/workflow-run#sha256" },
@@ -469,6 +470,19 @@
     ]
   },
   { 
+    "@id": "https://w3id.org/ro/terms/workflow-run#resourceUsage",
+    "@type": ["DefinedTerm", "rdf:Property"],
+    "termCode": "resourceUsage",
+    "name": "resource usage",
+    "description": "A resource usage item, such as peak memory",
+    "domainIncludes": [
+      {"@id": "http://schema.org/CreateAction"}
+    ],
+    "rangeIncludes": [
+      { "@id": "http://schema.org/PropertyValue" }
+    ]
+  },
+  {
     "@id": "https://w3id.org/ro/terms/workflow-run#md5",
     "@type": ["DefinedTerm", "rdf:Property"],
     "termCode": "md5",

--- a/docs/profiles/0.5-DRAFT/process_run_crate/ro-crate-preview.html
+++ b/docs/profiles/0.5-DRAFT/process_run_crate/ro-crate-preview.html
@@ -6,7 +6,9 @@
 
 <script type="application/ld+json"> 
   {
-  "@context": "https://w3id.org/ro/crate/1.2-DRAFT/context",
+  "@context": [
+    "https://w3id.org/ro/crate/1.2-DRAFT/context"
+  ],
   "@graph": [
     {
       "@id": "ro-crate-metadata.json",
@@ -391,6 +393,9 @@
         },
         {
           "@id": "https://w3id.org/ro/terms/workflow-run#containerImage"
+        },
+        {
+          "@id": "https://w3id.org/ro/terms/workflow-run#resourceUsage"
         },
         {
           "@id": "https://w3id.org/ro/terms/workflow-run#md5"
@@ -1129,6 +1134,22 @@
       ]
     },
     {
+      "@id": "https://w3id.org/ro/terms/workflow-run#resourceUsage",
+      "@type": [
+        "DefinedTerm",
+        "rdf:Property"
+      ],
+      "termCode": "resourceUsage",
+      "name": "resource usage",
+      "description": "A resource usage item, such as peak memory",
+      "domainIncludes": {
+        "@id": "http://schema.org/CreateAction"
+      },
+      "rangeIncludes": {
+        "@id": "http://schema.org/PropertyValue"
+      }
+    },
+    {
       "@id": "https://w3id.org/ro/terms/workflow-run#md5",
       "@type": [
         "DefinedTerm",
@@ -1270,8 +1291,8 @@ table.table {
   </nav>
 <div class="container">
 <div class="jumbotron">
-<h4 class="citation"></h3>
-<h3 class="item_name">Process Run Crate profile</h4>
+<h4 class="citation"></h4>
+<h3 class="item_name">Process Run Crate profile</h3>
 
 
 <a href="./ro-crate-metadata.json">⬇️🏷️ Download all the metadata for <span class='name'>Process Run Crate profile</span> in JSON-LD format</a>
@@ -1286,12 +1307,12 @@ table.table {
 
 <div id="summary">
 <div class='all-meta'>
-           <div>
-            <h3><a href="https://w3id.org/ro/wfrun/process/0.5-DRAFT">Go to: </a> Process Run Crate profile</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://w3id.org/ro/wfrun/process/0.5-DRAFT">Go to: </a> Process Run Crate profile</h3>
+                
+                
+                
+                
         <div id="https://w3id.org/ro/wfrun/process/0.5-DRAFT">
             
             <table class="table metadata table-striped" >
@@ -1414,15 +1435,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://www.researchobject.org/workflow-run-crate/">Go to: </a> Workflow Run Crate task force</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://www.researchobject.org/workflow-run-crate/">Go to: </a> Workflow Run Crate task force</h3>
+                
+                
+                
+                
         <div id="https://www.researchobject.org/workflow-run-crate/">
             
             <table class="table metadata table-striped" >
@@ -1523,15 +1543,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/><hr/><br/><br/>
-           <div>
-            <h3><a href="https://www.apache.org/licenses/LICENSE-2.0">Go to: </a> Apache License 2.0</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://www.apache.org/licenses/LICENSE-2.0">Go to: </a> Apache License 2.0</h3>
+                
+                
+                
+                
         <div id="https://www.apache.org/licenses/LICENSE-2.0">
             
             <table class="table metadata table-striped" >
@@ -1556,15 +1575,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="index.html">⬇️ Download: </a> Process Run Crate (HTML)</h3>
-            
-            <iframe src='index.html' width='100%' height='500'></iframe>
-            
-            
+            <div>
+                <h3><a href="index.html">⬇️ Download: </a> Process Run Crate (HTML)</h3>
+                
+                <iframe src='index.html' width='100%' height='500'></iframe>
+                
+                
         <div id="index.html">
             
             <table class="table metadata table-striped" >
@@ -1593,15 +1611,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> Example Process Run Crate</h3>
-            
-            
-            
-            
+            <div>
+                <h3> Example Process Run Crate</h3>
+                
+                
+                
+                
         <div id="example1/">
             
             <table class="table metadata table-striped" >
@@ -1637,15 +1654,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://www.researchobject.org/workflow-run-crate-paper/mapping/">Go to: </a> SSSOM mapping from PROV to Workflow Run Crate</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://www.researchobject.org/workflow-run-crate-paper/mapping/">Go to: </a> SSSOM mapping from PROV to Workflow Run Crate</h3>
+                
+                
+                
+                
         <div id="https://www.researchobject.org/workflow-run-crate-paper/mapping/">
             
             <table class="table metadata table-striped" >
@@ -1670,15 +1686,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://w3id.org/ro/terms/workflow-run#">Go to: </a> Namespace for Workflow Run RO-Crate model</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://w3id.org/ro/terms/workflow-run#">Go to: </a> Namespace for Workflow Run RO-Crate model</h3>
+                
+                
+                
+                
         <div id="https://w3id.org/ro/terms/workflow-run#">
             
             <table class="table metadata table-striped" >
@@ -1716,6 +1731,8 @@ table.table {
                         
                         <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23containerImage">container image</a></li>
                         
+                        <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23resourceUsage">resource usage</a></li>
+                        
                         <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23md5">md5 checksum</a></li>
                         
                         <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23sha1">sha1 checksum</a></li>
@@ -1736,15 +1753,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://w3id.org/ro/terms/workflow-run">Go to: </a> JSON-LD context for workflow-run terms</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://w3id.org/ro/terms/workflow-run">Go to: </a> JSON-LD context for workflow-run terms</h3>
+                
+                
+                
+                
         <div id="https://w3id.org/ro/terms/workflow-run">
             
             <table class="table metadata table-striped" >
@@ -1782,15 +1798,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://gxy.io/GTN:T00343">Go to: </a> Workflow Run RO-Crate Introduction</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://gxy.io/GTN:T00343">Go to: </a> Workflow Run RO-Crate Introduction</h3>
+                
+                
+                
+                
         <div id="https://gxy.io/GTN:T00343">
             
             <table class="table metadata table-striped" >
@@ -1815,15 +1830,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://pypi.org/project/runcrate/">Go to: </a> runcrate</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://pypi.org/project/runcrate/">Go to: </a> runcrate</h3>
+                
+                
+                
+                
         <div id="https://pypi.org/project/runcrate/">
             
             <table class="table metadata table-striped" >
@@ -1848,15 +1862,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/SoftwareApplication">Go to: </a> SoftwareApplication</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/SoftwareApplication">Go to: </a> SoftwareApplication</h3>
+                
+                
+                
+                
         <div id="http://schema.org/SoftwareApplication">
             
             <table class="table metadata table-striped" >
@@ -1878,15 +1891,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/SoftwareSourceCode">Go to: </a> SoftwareSourceCode</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/SoftwareSourceCode">Go to: </a> SoftwareSourceCode</h3>
+                
+                
+                
+                
         <div id="http://schema.org/SoftwareSourceCode">
             
             <table class="table metadata table-striped" >
@@ -1908,15 +1920,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://bioschemas.org/ComputationalWorkflow">Go to: </a> ComputationalWorkflow</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://bioschemas.org/ComputationalWorkflow">Go to: </a> ComputationalWorkflow</h3>
+                
+                
+                
+                
         <div id="https://bioschemas.org/ComputationalWorkflow">
             
             <table class="table metadata table-striped" >
@@ -1938,15 +1949,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/CreateAction">Go to: </a> CreateAction</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/CreateAction">Go to: </a> CreateAction</h3>
+                
+                
+                
+                
         <div id="http://schema.org/CreateAction">
             
             <table class="table metadata table-striped" >
@@ -1968,19 +1978,20 @@ table.table {
                         <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23environment">environment</a></li>
                         
                         <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23containerImage">container image</a></li>
+                        
+                        <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23resourceUsage">resource usage</a></li>
                         </ul></td>
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/name">Go to: </a> name</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/name">Go to: </a> name</h3>
+                
+                
+                
+                
         <div id="http://schema.org/name">
             
             <table class="table metadata table-striped" >
@@ -1999,15 +2010,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/description">Go to: </a> description</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/description">Go to: </a> description</h3>
+                
+                
+                
+                
         <div id="http://schema.org/description">
             
             <table class="table metadata table-striped" >
@@ -2026,15 +2036,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/endTime">Go to: </a> endTime</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/endTime">Go to: </a> endTime</h3>
+                
+                
+                
+                
         <div id="http://schema.org/endTime">
             
             <table class="table metadata table-striped" >
@@ -2053,15 +2062,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/startTime">Go to: </a> startTime</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/startTime">Go to: </a> startTime</h3>
+                
+                
+                
+                
         <div id="http://schema.org/startTime">
             
             <table class="table metadata table-striped" >
@@ -2080,15 +2088,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/instrument">Go to: </a> instrument</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/instrument">Go to: </a> instrument</h3>
+                
+                
+                
+                
         <div id="http://schema.org/instrument">
             
             <table class="table metadata table-striped" >
@@ -2107,15 +2114,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/agent">Go to: </a> agent</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/agent">Go to: </a> agent</h3>
+                
+                
+                
+                
         <div id="http://schema.org/agent">
             
             <table class="table metadata table-striped" >
@@ -2134,15 +2140,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/Person">Go to: </a> Person</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/Person">Go to: </a> Person</h3>
+                
+                
+                
+                
         <div id="http://schema.org/Person">
             
             <table class="table metadata table-striped" >
@@ -2161,15 +2166,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/Organization">Go to: </a> Organization</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/Organization">Go to: </a> Organization</h3>
+                
+                
+                
+                
         <div id="http://schema.org/Organization">
             
             <table class="table metadata table-striped" >
@@ -2188,15 +2192,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/object">Go to: </a> object</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/object">Go to: </a> object</h3>
+                
+                
+                
+                
         <div id="http://schema.org/object">
             
             <table class="table metadata table-striped" >
@@ -2215,15 +2218,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/result">Go to: </a> result</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/result">Go to: </a> result</h3>
+                
+                
+                
+                
         <div id="http://schema.org/result">
             
             <table class="table metadata table-striped" >
@@ -2242,15 +2244,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/actionStatus">Go to: </a> actionStatus</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/actionStatus">Go to: </a> actionStatus</h3>
+                
+                
+                
+                
         <div id="http://schema.org/actionStatus">
             
             <table class="table metadata table-striped" >
@@ -2269,15 +2270,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/error">Go to: </a> error</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/error">Go to: </a> error</h3>
+                
+                
+                
+                
         <div id="http://schema.org/error">
             
             <table class="table metadata table-striped" >
@@ -2296,15 +2296,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/CompletedActionStatus">Go to: </a> CompletedActionStatus</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/CompletedActionStatus">Go to: </a> CompletedActionStatus</h3>
+                
+                
+                
+                
         <div id="http://schema.org/CompletedActionStatus">
             
             <table class="table metadata table-striped" >
@@ -2323,15 +2322,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/FailedActionStatus">Go to: </a> FailedActionStatus</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/FailedActionStatus">Go to: </a> FailedActionStatus</h3>
+                
+                
+                
+                
         <div id="http://schema.org/FailedActionStatus">
             
             <table class="table metadata table-striped" >
@@ -2350,15 +2348,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/MediaObject">Go to: </a> MediaObject</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/MediaObject">Go to: </a> MediaObject</h3>
+                
+                
+                
+                
         <div id="http://schema.org/MediaObject">
             
             <table class="table metadata table-striped" >
@@ -2391,15 +2388,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/Dataset">Go to: </a> Dataset</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/Dataset">Go to: </a> Dataset</h3>
+                
+                
+                
+                
         <div id="http://schema.org/Dataset">
             
             <table class="table metadata table-striped" >
@@ -2418,15 +2414,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/Collection">Go to: </a> Collection</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/Collection">Go to: </a> Collection</h3>
+                
+                
+                
+                
         <div id="http://schema.org/Collection">
             
             <table class="table metadata table-striped" >
@@ -2445,15 +2440,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/CreativeWork">Go to: </a> CreativeWork</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/CreativeWork">Go to: </a> CreativeWork</h3>
+                
+                
+                
+                
         <div id="http://schema.org/CreativeWork">
             
             <table class="table metadata table-striped" >
@@ -2472,15 +2466,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/PropertyValue">Go to: </a> PropertyValue</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/PropertyValue">Go to: </a> PropertyValue</h3>
+                
+                
+                
+                
         <div id="http://schema.org/PropertyValue">
             
             <table class="table metadata table-striped" >
@@ -2498,19 +2491,22 @@ table.table {
             <td style='text-align:left'><a href="#https%3A//w3id.org/ro/wfrun/process/0.5-DRAFT">Process Run Crate profile</a></td>
             </tr><tr>
             <th style="text-align:left;" class="prop">rangeIncludes<span>&nbsp;</span><a href="http://schema.org/rangeIncludes">[?]</a></th>
-            <td style='text-align:left'><a href="#https%3A//w3id.org/ro/terms/workflow-run%23environment">environment</a></td>
+            <td style='text-align:left'><ul>
+                        <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23environment">environment</a></li>
+                        
+                        <li><a href="#https%3A//w3id.org/ro/terms/workflow-run%23resourceUsage">resource usage</a></li>
+                        </ul></td>
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/alternateName">Go to: </a> alternateName</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/alternateName">Go to: </a> alternateName</h3>
+                
+                
+                
+                
         <div id="http://schema.org/alternateName">
             
             <table class="table metadata table-striped" >
@@ -2529,15 +2525,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="http://schema.org/mainEntity">Go to: </a> mainEntity</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="http://schema.org/mainEntity">Go to: </a> mainEntity</h3>
+                
+                
+                
+                
         <div id="http://schema.org/mainEntity">
             
             <table class="table metadata table-striped" >
@@ -2556,15 +2551,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasSpecification</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasSpecification</h3>
+                
+                
+                
+                
         <div id="#hasSpecification">
             
             <table class="table metadata table-striped" >
@@ -2586,15 +2580,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasConstraints</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasConstraints</h3>
+                
+                
+                
+                
         <div id="#hasConstraints">
             
             <table class="table metadata table-striped" >
@@ -2616,15 +2609,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasVocabulary</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasVocabulary</h3>
+                
+                
+                
+                
         <div id="#hasVocabulary">
             
             <table class="table metadata table-striped" >
@@ -2646,15 +2638,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasGuidance</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasGuidance</h3>
+                
+                
+                
+                
         <div id="#hasGuidance">
             
             <table class="table metadata table-striped" >
@@ -2676,15 +2667,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasExample</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasExample</h3>
+                
+                
+                
+                
         <div id="#hasExample">
             
             <table class="table metadata table-striped" >
@@ -2706,15 +2696,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3> #hasMappingToProv</h3>
-            
-            
-            
-            
+            <div>
+                <h3> #hasMappingToProv</h3>
+                
+                
+                
+                
         <div id="#hasMappingToProv">
             
             <table class="table metadata table-striped" >
@@ -2736,15 +2725,14 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/>
-           <div>
-            <h3><a href="https://doi.org/10.48550/arXiv.2312.07852">Go to: </a> Recording provenance of workflow runs with RO-Crate</h3>
-            
-            
-            
-            
+            <div>
+                <h3><a href="https://doi.org/10.48550/arXiv.2312.07852">Go to: </a> Recording provenance of workflow runs with RO-Crate</h3>
+                
+                
+                
+                
         <div id="https://doi.org/10.48550/arXiv.2312.07852">
             
             <table class="table metadata table-striped" >
@@ -2805,8 +2793,7 @@ table.table {
             </tr></tbody>
             </table>
         </div>
-
-        </div>
+            </div>
         <hr/><br/><br/></div>
 </div>
 


### PR DESCRIPTION
https://github.com/ResearchObject/ro-terms/pull/21 was still open (it had only the first commit then) when #73 was merged, so `resourceUsage` was left out of the profile crate.